### PR TITLE
upgrading to version 10.4.1

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,12 +1,12 @@
 pkgname=vstudio
-pkgver=9.5.3
+pkgver=10.4.1
 pkgrel=1
 pkgdesc="GUI Admin Tool for MySQL, MariaDB, PostgreSQL, MS SQL Server, Valentina DB and SQLite"
 arch=('x86_64')
 url="http://www.valentina-db.com"
 license=('custom')
 source=("vstudio_x64_${pkgver}_lin.deb::https://valentina-db.com/en/all-downloads/vstudio/current/vstudio_x64_lin-deb")
-md5sums=('20b29f07d7e286927a6d37c437fb15d1')
+md5sums=('d6c44799bbc8265a3d52c2904a40adca')
 
 package() {
     bsdtar -xf data.tar.xz -C ${pkgdir}


### PR DESCRIPTION
The "current" used in the path will make this package break during installation on each new release, which I think is fine as it forces the PKGBUILD to keep up with the latest version